### PR TITLE
remove `exists` function

### DIFF
--- a/policy/Azure-Proactive-Resiliency-Library-v2/azapi/network/microsoft_network_applicationGateways_zones.rego
+++ b/policy/Azure-Proactive-Resiliency-Library-v2/azapi/network/microsoft_network_applicationGateways_zones.rego
@@ -3,7 +3,7 @@ package Azure_Proactive_Resiliency_Library_v2.Microsoft_Network_applicationGatew
 import rego.v1
 
 valid_zones(resource) if {
-    data.utils.exists(resource.values.body.zones)
+    resource.values.body.zones == resource.values.body.zones
     count(resource.values.body.zones) >= 2
 }
 

--- a/policy/Azure-Proactive-Resiliency-Library-v2/azapi/network/microsoft_network_loadBalancers_outbound_rules.rego
+++ b/policy/Azure-Proactive-Resiliency-Library-v2/azapi/network/microsoft_network_loadBalancers_outbound_rules.rego
@@ -7,7 +7,7 @@ valid_outbound_rules(resource) if {
 }
 
 valid_outbound_rules(resource) if {
-    not resource.values.body.properties.outboundRules
+    not resource.values.body.properties.outboundRules == resource.values.body.properties.outboundRules
 }
 
 deny_use_nat_gateway_instead_of_outbound_rules_for_production_load_lalancer contains reason if {

--- a/policy/Azure-Proactive-Resiliency-Library-v2/azurerm/network/azurerm_application_gateway_zones.rego
+++ b/policy/Azure-Proactive-Resiliency-Library-v2/azurerm/network/azurerm_application_gateway_zones.rego
@@ -3,7 +3,7 @@ package Azure_Proactive_Resiliency_Library_v2.azurerm_application_gateway
 import rego.v1
 
 valid_zones(resource) if {
-    data.utils.exists(resource.values.zones)
+    resource.values.zones == resource.values.zones
     count(resource.values.zones) >= 2
 }
 

--- a/policy/common/common.utils.rego
+++ b/policy/common/common.utils.rego
@@ -3,7 +3,7 @@ package utils
 import rego.v1
 
 _resource(_input) := output if {
-	exists(_input.plan.resource_changes)
+	_input.plan.resource_changes == _input.plan.resource_changes
 	output := {
 	body |
 		r := _input.plan.resource_changes[_]
@@ -17,7 +17,7 @@ _resource(_input) := output if {
 }
 
 _resource(_input) := output if {
-	exists(_input.resource_changes)
+	_input.resource_changes == _input.resource_changes
 	output := {
 	body |
 		r := _input.resource_changes[_]
@@ -31,7 +31,7 @@ _resource(_input) := output if {
 }
 
 _resource(_input) := output if {
-	exists(_input.values.root_module.resources)
+	_input.values.root_module.resources == _input.values.root_module.resources
 	output := {
 	body |
 		r := _input.values.root_module.resources[_]
@@ -49,10 +49,6 @@ resource |
 	some resource in _resource(_input)
 	resource.mode == "managed"
 	resource.type == resource_type
-}
-
-exists(x) if {
-	x == x
 }
 
 is_create_or_update(change_actions) if {


### PR DESCRIPTION
An `exists` function lure users into thinking they can use a `not exists()` check, or a `not_exists()` function, which is not correct. When we pass a non-exist path as function's parameter, the whole rule check stops with result as undefined. None of `not exists(non_exist_path) nor `not_exists(non_exist_path)` works as expected.

Another classic approach is to check existence is like:

```rego
rule1 := true if {
    input.foo.bar
}
```

If we'd like to assert that the path is not existed, we might use:

```rego
rule1 := true if {
    not input.foo.bar
}
```

But this rule would return a false result if `input.foo.bar`'s type is boolean and the value is `false`.

The correct way to check non-existence is:

```rego
rule1 := true if {
    not input.foo.bar == input.foo.bar
}
```

In rego, `==` function wouldn't be effected by a non-exist path. For symmetry reasons, we stipulate that in this library, we must check the existence by:

```rego
exist := true if {
    input.foo.bar == input.foo.bar
}
not_exist := true if {
    not input.foo.bar == input.foo.bar
}
```