### PR TITLE
feat: add StoragePublicNetworkAccessDisabledWithPE rule

### DIFF
--- a/policy/avmsec/StoragePublicNetworkAccessDisabledWithPE.azapi.mock.json
+++ b/policy/avmsec/StoragePublicNetworkAccessDisabledWithPE.azapi.mock.json
@@ -1,0 +1,357 @@
+{
+  "mock": {
+    "invalid_rootModule_pe_public_access": {
+      "resource_changes": [
+        {
+          "address": "azapi_resource.storage",
+          "mode": "managed",
+          "type": "azapi_resource",
+          "name": "storage",
+          "provider_name": "registry.terraform.io/azure/azapi",
+          "change": {
+            "actions": ["create"],
+            "after": {
+              "type": "Microsoft.Storage/storageAccounts@2023-05-01",
+              "body": {
+                "properties": {
+                  "publicNetworkAccess": "Enabled"
+                }
+              }
+            }
+          }
+        },
+        {
+          "address": "azapi_resource.pe",
+          "mode": "managed",
+          "type": "azapi_resource",
+          "name": "pe",
+          "provider_name": "registry.terraform.io/azure/azapi",
+          "change": {
+            "actions": ["create"],
+            "after": {
+              "type": "Microsoft.Network/privateEndpoints@2024-05-01",
+              "body": {
+                "properties": {
+                  "privateLinkServiceConnections": [
+                    {
+                      "properties": {
+                        "privateLinkServiceId": "/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ],
+      "configuration": {
+        "root_module": {
+          "resources": [
+            {
+              "address": "azapi_resource.storage",
+              "mode": "managed",
+              "type": "azapi_resource",
+              "name": "storage",
+              "provider_config_key": "azapi",
+              "expressions": {}
+            },
+            {
+              "address": "azapi_resource.pe",
+              "mode": "managed",
+              "type": "azapi_resource",
+              "name": "pe",
+              "provider_config_key": "azapi",
+              "expressions": {
+                "body": {
+                  "references": [
+                    "azapi_resource.storage.output.id",
+                    "azapi_resource.storage"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "invalid_nestedModule_pe_public_access": {
+      "resource_changes": [
+        {
+          "address": "module.storage.azapi_resource.this",
+          "module_address": "module.storage",
+          "mode": "managed",
+          "type": "azapi_resource",
+          "name": "this",
+          "provider_name": "registry.terraform.io/azure/azapi",
+          "change": {
+            "actions": ["create"],
+            "after": {
+              "type": "Microsoft.Storage/storageAccounts@2023-05-01",
+              "body": {
+                "properties": {
+                  "publicNetworkAccess": "Enabled"
+                }
+              }
+            }
+          }
+        },
+        {
+          "address": "module.storage.azapi_resource.pe",
+          "module_address": "module.storage",
+          "mode": "managed",
+          "type": "azapi_resource",
+          "name": "pe",
+          "provider_name": "registry.terraform.io/azure/azapi",
+          "change": {
+            "actions": ["create"],
+            "after": {
+              "type": "Microsoft.Network/privateEndpoints@2024-05-01",
+              "body": {
+                "properties": {
+                  "privateLinkServiceConnections": [
+                    {
+                      "properties": {
+                        "privateLinkServiceId": "/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ],
+      "configuration": {
+        "root_module": {
+          "module_calls": {
+            "storage": {
+              "module": {
+                "resources": [
+                  {
+                    "address": "azapi_resource.this",
+                    "mode": "managed",
+                    "type": "azapi_resource",
+                    "name": "this",
+                    "provider_config_key": "azapi",
+                    "expressions": {}
+                  },
+                  {
+                    "address": "azapi_resource.pe",
+                    "mode": "managed",
+                    "type": "azapi_resource",
+                    "name": "pe",
+                    "provider_config_key": "azapi",
+                    "expressions": {
+                      "body": {
+                        "references": [
+                          "azapi_resource.this.output.id",
+                          "azapi_resource.this"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "invalid_state_pe_public_access": {
+      "values": {
+        "root_module": {
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.storage.azapi_resource.this",
+                  "mode": "managed",
+                  "type": "azapi_resource",
+                  "name": "this",
+                  "provider_name": "registry.terraform.io/azure/azapi",
+                  "values": {
+                    "id": "/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx",
+                    "type": "Microsoft.Storage/storageAccounts@2023-05-01",
+                    "body": {
+                      "properties": {
+                        "publicNetworkAccess": "Enabled"
+                      }
+                    }
+                  }
+                },
+                {
+                  "address": "module.storage.azapi_resource.pe",
+                  "mode": "managed",
+                  "type": "azapi_resource",
+                  "name": "pe",
+                  "provider_name": "registry.terraform.io/azure/azapi",
+                  "values": {
+                    "type": "Microsoft.Network/privateEndpoints@2024-05-01",
+                    "body": {
+                      "properties": {
+                        "privateLinkServiceConnections": [
+                          {
+                            "properties": {
+                              "privateLinkServiceId": "/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "pe_public_access_disabled": {
+      "resource_changes": [
+        {
+          "address": "azapi_resource.storage",
+          "mode": "managed",
+          "type": "azapi_resource",
+          "name": "storage",
+          "provider_name": "registry.terraform.io/azure/azapi",
+          "change": {
+            "actions": ["create"],
+            "after": {
+              "type": "Microsoft.Storage/storageAccounts@2023-05-01",
+              "body": {
+                "properties": {
+                  "publicNetworkAccess": "Disabled"
+                }
+              }
+            }
+          }
+        },
+        {
+          "address": "azapi_resource.pe",
+          "mode": "managed",
+          "type": "azapi_resource",
+          "name": "pe",
+          "provider_name": "registry.terraform.io/azure/azapi",
+          "change": {
+            "actions": ["create"],
+            "after": {
+              "type": "Microsoft.Network/privateEndpoints@2024-05-01",
+              "body": {
+                "properties": {
+                  "privateLinkServiceConnections": [
+                    {
+                      "properties": {
+                        "privateLinkServiceId": "/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ],
+      "configuration": {
+        "root_module": {
+          "resources": [
+            {
+              "address": "azapi_resource.storage",
+              "mode": "managed",
+              "type": "azapi_resource",
+              "name": "storage",
+              "provider_config_key": "azapi",
+              "expressions": {}
+            },
+            {
+              "address": "azapi_resource.pe",
+              "mode": "managed",
+              "type": "azapi_resource",
+              "name": "pe",
+              "provider_config_key": "azapi",
+              "expressions": {
+                "body": {
+                  "references": [
+                    "azapi_resource.storage.output.id",
+                    "azapi_resource.storage"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "no_pe_public_access_enabled": {
+      "resource_changes": [
+        {
+          "address": "azapi_resource.storage",
+          "mode": "managed",
+          "type": "azapi_resource",
+          "name": "storage",
+          "provider_name": "registry.terraform.io/azure/azapi",
+          "change": {
+            "actions": ["create"],
+            "after": {
+              "type": "Microsoft.Storage/storageAccounts@2023-05-01",
+              "body": {
+                "properties": {
+                  "publicNetworkAccess": "Enabled"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "valid_state_pe_public_access_disabled": {
+      "values": {
+        "root_module": {
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.storage.azapi_resource.this",
+                  "mode": "managed",
+                  "type": "azapi_resource",
+                  "name": "this",
+                  "provider_name": "registry.terraform.io/azure/azapi",
+                  "values": {
+                    "id": "/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx",
+                    "type": "Microsoft.Storage/storageAccounts@2023-05-01",
+                    "body": {
+                      "properties": {
+                        "publicNetworkAccess": "Disabled"
+                      }
+                    }
+                  }
+                },
+                {
+                  "address": "module.storage.azapi_resource.pe",
+                  "mode": "managed",
+                  "type": "azapi_resource",
+                  "name": "pe",
+                  "provider_name": "registry.terraform.io/azure/azapi",
+                  "values": {
+                    "type": "Microsoft.Network/privateEndpoints@2024-05-01",
+                    "body": {
+                      "properties": {
+                        "privateLinkServiceConnections": [
+                          {
+                            "properties": {
+                              "privateLinkServiceId": "/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/policy/avmsec/StoragePublicNetworkAccessDisabledWithPE.azapi.rego
+++ b/policy/avmsec/StoragePublicNetworkAccessDisabledWithPE.azapi.rego
@@ -1,0 +1,30 @@
+package avmsec
+
+import rego.v1
+
+# For state file: check by resource id
+has_private_endpoint_azapi_storage_account(storage_account) if {
+    storage_account_id := storage_account.values.id
+    private_endpoint := data.utils.resource(input, "azapi_resource")[_]
+    data.utils.is_azure_type(private_endpoint.values, "Microsoft.Network/privateEndpoints")
+    private_endpoint.values.body.properties.privateLinkServiceConnections[_].properties.privateLinkServiceId == storage_account_id
+}
+
+# For plan file: check by configuration references
+has_private_endpoint_azapi_storage_account(storage_account) if {
+    private_endpoint_config := data.utils.resource_configuration(input)[_]
+    private_endpoint_config.type == "azapi_resource"
+    data.utils.arraycontains(
+        [sprintf("%s%s", [private_endpoint_config.module_prefix, ref]) |
+            some ref in private_endpoint_config.expressions.body.references],
+        sprintf("%s.%s", [storage_account.address, "output.id"])
+    )
+}
+
+deny_AVM_SEC_STORAGE_PE_PUBLIC_ACCESS contains reason if {
+    storage_account := data.utils.resource(input, "azapi_resource")[_]
+    data.utils.is_azure_type(storage_account.values, "Microsoft.Storage/storageAccounts")
+    storage_account.values.body.properties.publicNetworkAccess == "Enabled"
+    has_private_endpoint_azapi_storage_account(storage_account)
+    reason := sprintf("avmsec/AVM_SEC_STORAGE_PE_PUBLIC_ACCESS: Storage account with private endpoint should disable public network access (publicNetworkAccess should be Disabled): %s", [storage_account.address])
+}

--- a/policy/avmsec/StoragePublicNetworkAccessDisabledWithPE.mock.json
+++ b/policy/avmsec/StoragePublicNetworkAccessDisabledWithPE.mock.json
@@ -1,0 +1,286 @@
+{
+  "mock": {
+    "invalid_rootModule_pe_public_access": {
+      "resource_changes": [
+        {
+          "address": "azurerm_storage_account.this",
+          "mode": "managed",
+          "type": "azurerm_storage_account",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/azurerm",
+          "change": {
+            "actions": ["create"],
+            "after": {
+              "public_network_access_enabled": true
+            }
+          }
+        },
+        {
+          "address": "azurerm_private_endpoint.pe",
+          "mode": "managed",
+          "type": "azurerm_private_endpoint",
+          "name": "pe",
+          "provider_name": "registry.terraform.io/hashicorp/azurerm",
+          "change": {
+            "actions": ["create"],
+            "after": {}
+          }
+        }
+      ],
+      "configuration": {
+        "root_module": {
+          "resources": [
+            {
+              "address": "azurerm_storage_account.this",
+              "mode": "managed",
+              "type": "azurerm_storage_account",
+              "name": "this",
+              "provider_config_key": "azurerm",
+              "expressions": {}
+            },
+            {
+              "address": "azurerm_private_endpoint.pe",
+              "mode": "managed",
+              "type": "azurerm_private_endpoint",
+              "name": "pe",
+              "provider_config_key": "azurerm",
+              "expressions": {
+                "private_service_connection": [
+                  {
+                    "private_connection_resource_id": {
+                      "references": [
+                        "azurerm_storage_account.this.id",
+                        "azurerm_storage_account.this"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "invalid_nestedModule_pe_public_access": {
+      "resource_changes": [
+        {
+          "address": "module.storage.azurerm_storage_account.this",
+          "module_address": "module.storage",
+          "mode": "managed",
+          "type": "azurerm_storage_account",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/azurerm",
+          "change": {
+            "actions": ["create"],
+            "after": {
+              "public_network_access_enabled": true
+            }
+          }
+        },
+        {
+          "address": "module.storage.azurerm_private_endpoint.pe",
+          "module_address": "module.storage",
+          "mode": "managed",
+          "type": "azurerm_private_endpoint",
+          "name": "pe",
+          "provider_name": "registry.terraform.io/hashicorp/azurerm",
+          "change": {
+            "actions": ["create"],
+            "after": {}
+          }
+        }
+      ],
+      "configuration": {
+        "root_module": {
+          "module_calls": {
+            "storage": {
+              "module": {
+                "resources": [
+                  {
+                    "address": "azurerm_storage_account.this",
+                    "mode": "managed",
+                    "type": "azurerm_storage_account",
+                    "name": "this",
+                    "provider_config_key": "azurerm",
+                    "expressions": {}
+                  },
+                  {
+                    "address": "azurerm_private_endpoint.pe",
+                    "mode": "managed",
+                    "type": "azurerm_private_endpoint",
+                    "name": "pe",
+                    "provider_config_key": "azurerm",
+                    "expressions": {
+                      "private_service_connection": [
+                        {
+                          "private_connection_resource_id": {
+                            "references": [
+                              "azurerm_storage_account.this.id",
+                              "azurerm_storage_account.this"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "invalid_state_pe_public_access": {
+      "values": {
+        "root_module": {
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.storage.azurerm_storage_account.this",
+                  "mode": "managed",
+                  "type": "azurerm_storage_account",
+                  "name": "this",
+                  "provider_name": "registry.terraform.io/hashicorp/azurerm",
+                  "values": {
+                    "id": "/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx",
+                    "public_network_access_enabled": true
+                  }
+                },
+                {
+                  "address": "module.storage.azurerm_private_endpoint.pe",
+                  "mode": "managed",
+                  "type": "azurerm_private_endpoint",
+                  "name": "pe",
+                  "provider_name": "registry.terraform.io/hashicorp/azurerm",
+                  "values": {
+                    "private_service_connection": [
+                      {
+                        "private_connection_resource_id": "/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "pe_public_access_disabled": {
+      "resource_changes": [
+        {
+          "address": "azurerm_storage_account.this",
+          "mode": "managed",
+          "type": "azurerm_storage_account",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/azurerm",
+          "change": {
+            "actions": ["create"],
+            "after": {
+              "public_network_access_enabled": false
+            }
+          }
+        },
+        {
+          "address": "azurerm_private_endpoint.pe",
+          "mode": "managed",
+          "type": "azurerm_private_endpoint",
+          "name": "pe",
+          "provider_name": "registry.terraform.io/hashicorp/azurerm",
+          "change": {
+            "actions": ["create"],
+            "after": {}
+          }
+        }
+      ],
+      "configuration": {
+        "root_module": {
+          "resources": [
+            {
+              "address": "azurerm_storage_account.this",
+              "mode": "managed",
+              "type": "azurerm_storage_account",
+              "name": "this",
+              "provider_config_key": "azurerm",
+              "expressions": {}
+            },
+            {
+              "address": "azurerm_private_endpoint.pe",
+              "mode": "managed",
+              "type": "azurerm_private_endpoint",
+              "name": "pe",
+              "provider_config_key": "azurerm",
+              "expressions": {
+                "private_service_connection": [
+                  {
+                    "private_connection_resource_id": {
+                      "references": [
+                        "azurerm_storage_account.this.id",
+                        "azurerm_storage_account.this"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "no_pe_public_access_enabled": {
+      "resource_changes": [
+        {
+          "address": "azurerm_storage_account.this",
+          "mode": "managed",
+          "type": "azurerm_storage_account",
+          "name": "this",
+          "provider_name": "registry.terraform.io/hashicorp/azurerm",
+          "change": {
+            "actions": ["create"],
+            "after": {
+              "public_network_access_enabled": true
+            }
+          }
+        }
+      ]
+    },
+    "valid_state_pe_public_access_disabled": {
+      "values": {
+        "root_module": {
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.storage.azurerm_storage_account.this",
+                  "mode": "managed",
+                  "type": "azurerm_storage_account",
+                  "name": "this",
+                  "provider_name": "registry.terraform.io/hashicorp/azurerm",
+                  "values": {
+                    "id": "/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx",
+                    "public_network_access_enabled": false
+                  }
+                },
+                {
+                  "address": "module.storage.azurerm_private_endpoint.pe",
+                  "mode": "managed",
+                  "type": "azurerm_private_endpoint",
+                  "name": "pe",
+                  "provider_name": "registry.terraform.io/hashicorp/azurerm",
+                  "values": {
+                    "private_service_connection": [
+                      {
+                        "private_connection_resource_id": "/subscriptions/xxxxx/resourceGroups/xxxxx/providers/Microsoft.Storage/storageAccounts/xxxxx"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/policy/avmsec/StoragePublicNetworkAccessDisabledWithPE.rego
+++ b/policy/avmsec/StoragePublicNetworkAccessDisabledWithPE.rego
@@ -1,0 +1,28 @@
+package avmsec
+
+import rego.v1
+
+# For state file: check by resource id
+has_private_endpoint_azurerm_storage_account(storage_account) if {
+    storage_account_id := storage_account.values.id
+    private_endpoint := data.utils.resource(input, "azurerm_private_endpoint")[_]
+    private_endpoint.values.private_service_connection[0].private_connection_resource_id == storage_account_id
+}
+
+# For plan file: check by configuration references
+has_private_endpoint_azurerm_storage_account(storage_account) if {
+    private_endpoint_config := data.utils.resource_configuration(input)[_]
+    private_endpoint_config.type == "azurerm_private_endpoint"
+    data.utils.arraycontains(
+        [sprintf("%s%s", [private_endpoint_config.module_prefix, ref]) |
+            some ref in private_endpoint_config.expressions.private_service_connection[_].private_connection_resource_id.references],
+        sprintf("%s.%s", [storage_account.address, "id"])
+    )
+}
+
+deny_AVM_SEC_STORAGE_PE_PUBLIC_ACCESS contains reason if {
+    storage_account := data.utils.resource(input, "azurerm_storage_account")[_]
+    storage_account.values.public_network_access_enabled == true
+    has_private_endpoint_azurerm_storage_account(storage_account)
+    reason := sprintf("avmsec/AVM_SEC_STORAGE_PE_PUBLIC_ACCESS: Storage account with private endpoint should disable public network access (public_network_access_enabled should be false): %s", [storage_account.address])
+}

--- a/policy/avmsec/readme.md
+++ b/policy/avmsec/readme.md
@@ -27,6 +27,7 @@ According to [Checkov general policies for Azure](https://docs.prismacloud.io/en
 | Backend of the API management system does not utilize HTTPS | AVM_SEC_215 | HIGH |
 | Event Hub Namespace not using TLS 1.2 or greater | AVM_SEC_223 | HIGH |
 | Linux VM Without SSH Key | AVM_SEC_178 | HIGH |
+| Storage account with private endpoint should disable public network access | AVM_SEC_STORAGE_PE_PUBLIC_ACCESS | HIGH |
 | Storage for critical data are not encrypted with Customer Managed Key | AVM_SEC_2_1 | HIGH |
 | AKS Secrets Store Without Auto-Rotation | AVM_SEC_172 | MEDIUM |
 | API Management Without Minimum TLS 1.2 | AVM_SEC_173 | MEDIUM |

--- a/policy/avmsec/severity.rego
+++ b/policy/avmsec/severity.rego
@@ -13,6 +13,7 @@ high_severity_rules := [
 	"AVM_SEC_223",
 	"AVM_SEC_178",
 	"AVM_SEC_AZPOLICY_BUILTIN_1",
+	"AVM_SEC_STORAGE_PE_PUBLIC_ACCESS",
 ]
 
 medium_severity_rules := [


### PR DESCRIPTION
## Summary

Add new avmsec rule: **StoragePublicNetworkAccessDisabledWithPE**

If a storage account has a private endpoint association, its `public_network_access_enabled` (azurerm) / `publicNetworkAccess` (azapi) must not be enabled.

## Rule Logic

The rule uses two detection methods depending on input format:

1. **Plan file** (terraform plan -json): Checks `configuration.expressions` references to find PE resources referencing the storage account
2. **State file** (terraform show -json): Checks if any PE `private_service_connection.private_connection_resource_id` matches the storage account `id`

## Files Added

| File | Description |
|------|-------------|
| `StoragePublicNetworkAccessDisabledWithPE.rego` | azurerm version rule |
| `StoragePublicNetworkAccessDisabledWithPE.mock.json` | azurerm mock tests (6 cases) |
| `StoragePublicNetworkAccessDisabledWithPE.azapi.rego` | azapi version rule |
| `StoragePublicNetworkAccessDisabledWithPE.azapi.mock.json` | azapi mock tests (6 cases) |

## Test Cases — azurerm (.rego)

### Should PASS (valid cases)

| Case Name | Scenario | Why it passes |
|-----------|----------|---------------|
| `pe_public_access_disabled` | Root module plan: storage account has PE, `public_network_access_enabled = false` | PE exists but public access is already disabled — compliant |
| `no_pe_public_access_enabled` | Root module plan: storage account has `public_network_access_enabled = true`, but **no** PE | No PE association — rule does not apply |
| `valid_state_pe_public_access_disabled` | State file: storage account in child module has PE, `public_network_access_enabled = false` | PE exists but public access is disabled — compliant |

### Should FAIL (invalid cases)

| Case Name | Scenario | Why it fails |
|-----------|----------|--------------|
| `invalid_rootModule_pe_public_access` | Root module plan: storage account has PE + `public_network_access_enabled = true` | PE exists and public access is enabled — violation |
| `invalid_nestedModule_pe_public_access` | Nested module plan: storage account in `module.storage` has PE + `public_network_access_enabled = true` | Same violation inside a module block |
| `invalid_state_pe_public_access` | State file: storage account in child module has PE + `public_network_access_enabled = true` | State file shows PE linked via matching resource IDs + public access enabled |

## Test Cases — azapi (.azapi.rego)

### Should PASS (valid cases)

| Case Name | Scenario | Why it passes |
|-----------|----------|---------------|
| `pe_public_access_disabled` | Root module plan: `azapi_resource` storage has PE, `publicNetworkAccess = "Disabled"` | PE exists but public access is Disabled — compliant |
| `no_pe_public_access_enabled` | Root module plan: storage has `publicNetworkAccess = "Enabled"`, but **no** PE | No PE — rule does not apply |
| `valid_state_pe_public_access_disabled` | State file: storage in child module has PE, `publicNetworkAccess = "Disabled"` | PE exists but public access is Disabled — compliant |

### Should FAIL (invalid cases)

| Case Name | Scenario | Why it fails |
|-----------|----------|--------------|
| `invalid_rootModule_pe_public_access` | Root module plan: `azapi_resource` storage has PE (via `body.references`) + `publicNetworkAccess = "Enabled"` | PE exists and public access is Enabled — violation |
| `invalid_nestedModule_pe_public_access` | Nested module plan: storage in `module.storage` has PE + `publicNetworkAccess = "Enabled"` | Same violation inside a module block |
| `invalid_state_pe_public_access` | State file: storage has PE (matched via `privateLinkServiceId == id`) + `publicNetworkAccess = "Enabled"` | State file shows PE linked + public access Enabled |

## Verification

- AzAPI schema verified via MCP terraform tools (`body.properties.publicNetworkAccess`: String Enabled/Disabled/SecuredByPerimeter)
- PE schema verified via `az resource show` (`properties.privateLinkServiceConnections[].properties.privateLinkServiceId`)
- Tested against real `terraform plan` and `terraform show` outputs from Azure/avm-res-storage-storageaccount module v0.6.7
- All 12 test cases passing locally via avmpolicytester
