### PR TITLE
fix: azapi appgw autoscale policy checks min_capacity instead of minCapacity

### DIFF
--- a/policy/Azure-Proactive-Resiliency-Library-v2/azapi/network/microsoft_network_applicationGateways_autoscale_enabled.mock.json
+++ b/policy/Azure-Proactive-Resiliency-Library-v2/azapi/network/microsoft_network_applicationGateways_autoscale_enabled.mock.json
@@ -20,64 +20,63 @@
                                         "minCapacity": 2
                                     }
                                 }
-                            }
-                        },
-                        "name": "example-appgateway",
-                        "type": "Microsoft.Network/applicationGateways@2024-03-01"
+                            },
+                            "name": "example-appgateway",
+                            "type": "Microsoft.Network/applicationGateways@2024-03-01"
+                        }
                     }
                 }
             ]
-        }
-    },
-    "as_min_zero_no_max": {
-        "resource_changes": [
-            {
-                "address": "azapi_resource.gw",
-                "mode": "managed",
-                "type": "azapi_resource",
-                "name": "gw",
-                "provider_name": "registry.terraform.io/azure/azapi",
-                "change": {
-                    "actions": [
-                        "create"
-                    ],
-                    "after": {
-                        "body": {
-                            "properties": {
-                                "autoscaleConfiguration": {
-                                    "minCapacity": 2
+        },
+        "as_min_only_no_max": {
+            "resource_changes": [
+                {
+                    "address": "azapi_resource.gw",
+                    "mode": "managed",
+                    "type": "azapi_resource",
+                    "name": "gw",
+                    "provider_name": "registry.terraform.io/azure/azapi",
+                    "change": {
+                        "actions": [
+                            "create"
+                        ],
+                        "after": {
+                            "body": {
+                                "properties": {
+                                    "autoscaleConfiguration": {
+                                        "minCapacity": 2
+                                    }
                                 }
-                            }
-                        },
-                        "name": "example-appgateway",
-                        "type": "Microsoft.Network/applicationGateways@2024-03-01"
+                            },
+                            "name": "example-appgateway",
+                            "type": "Microsoft.Network/applicationGateways@2024-03-01"
+                        }
                     }
                 }
-            }
-        ]
-    },
-    "invalid_no_as": {
-        "resource_changes": [
-            {
-                "address": "azapi_resource.gw",
-                "mode": "managed",
-                "type": "azapi_resource",
-                "name": "gw",
-                "provider_name": "registry.terraform.io/azure/azapi",
-                "change": {
-                    "actions": [
-                        "create"
-                    ],
-                    "after": {
-                        "body": {},
-                        "name": "example-appgateway",
-                        "type": "Microsoft.Network/applicationGateways@2024-03-01"
+            ]
+        },
+        "invalid_no_autoscale": {
+            "resource_changes": [
+                {
+                    "address": "azapi_resource.gw",
+                    "mode": "managed",
+                    "type": "azapi_resource",
+                    "name": "gw",
+                    "provider_name": "registry.terraform.io/azure/azapi",
+                    "change": {
+                        "actions": [
+                            "create"
+                        ],
+                        "after": {
+                            "body": {},
+                            "name": "example-appgateway",
+                            "type": "Microsoft.Network/applicationGateways@2024-03-01"
+                        }
                     }
                 }
-            }
-        ]
-    },
-    "invalid_min_capactiy_1": {
+            ]
+        },
+        "invalid_min_capacity_1": {
             "resource_changes": [
                 {
                     "address": "azapi_resource.gw",
@@ -97,12 +96,13 @@
                                         "minCapacity": 1
                                     }
                                 }
-                            }
-                        },
-                        "name": "example-appgateway",
-                        "type": "Microsoft.Network/applicationGateways@2024-03-01"
+                            },
+                            "name": "example-appgateway",
+                            "type": "Microsoft.Network/applicationGateways@2024-03-01"
+                        }
                     }
                 }
             ]
         }
+    }
 }

--- a/policy/Azure-Proactive-Resiliency-Library-v2/azapi/network/microsoft_network_applicationGateways_autoscale_enabled.rego
+++ b/policy/Azure-Proactive-Resiliency-Library-v2/azapi/network/microsoft_network_applicationGateways_autoscale_enabled.rego
@@ -3,7 +3,7 @@ package Azure_Proactive_Resiliency_Library_v2
 import rego.v1
 
 valid_azapi_ensure_autoscale_feature_has_been_enabled(resource) if {
-    resource.values.body.properties.autoscaleConfiguration.min_capacity > 1
+    resource.values.body.properties.autoscaleConfiguration.minCapacity > 1
 }
 
 deny_application_gateway_ensure_autoscale_feature_has_been_enabled contains reason if {


### PR DESCRIPTION
## Problem

The azapi provider serialises Application Gateway autoscale configuration using camelCase property names (`minCapacity` / `maxCapacity`), matching the ARM REST API. The Rego rule was checking the snake_case key `min_capacity`, which **never exists** in an azapi tfplan  so the policy always evaluated to `deny` regardless of what was configured, forcing consumers to add an APRL exception just to pass `avm pr-check`.JSON 

Reported while fixing [terraform-azurerm-avm-res-network-applicationgateway](https://github.com/Azure/terraform-azurerm-avm-res-network-applicationgateway) for its azapi migration.

## Changes

### `microsoft_network_applicationGateways_autoscale_enabled.rego`
 `autoscaleConfiguration.minCapacity`

### `microsoft_network_applicationGateways_autoscale_enabled.mock.json`
- Move `as_min_zero_no_max`, `invalid_no_as`, `invalid_min_capactiy_1` inside the top-level `"mock"`  they were orphaned at the JSON root and never executed by conftestobject 
- Rename cases to clearer names: `as_min_only_no_max`, `invalid_no_autoscale`, `invalid_min_capacity_1`
 `capacity`
- Fix `"after"` object nesting: `name`/`type` were inside `body.properties` instead of alongside `body`

## Testing

The mock cases now cover all four scenarios:

| Mock key | Description | Expected |
|---|---|---|
| `as_max_min_set` | minCapacity=2, maxCapacity=2 | pass |
| `as_min_only_no_max` | minCapacity=2, no max | pass |
| `invalid_no_autoscale` | no autoscaleConfiguration | deny |
| `invalid_min_capacity_1` | minCapacity=1 | deny |
